### PR TITLE
Add ActivityCategory Endpoint

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/constant/ActivityCategory.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/constant/ActivityCategory.java
@@ -22,7 +22,7 @@ public enum ActivityCategory {
         this.icon = icon;
     }
 
-    public String toString() {
+    public String getIcon() {
         return this.icon;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/constant/ActivityCategory.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/constant/ActivityCategory.java
@@ -1,18 +1,28 @@
 package ch.uzh.ifi.hase.soprafs21.constant;
 
 public enum ActivityCategory {
-    COOKING,
-    EATING,
-    THEATRE,
-    MOVIES,
-    MUSIC,
-    MUSEUMS,
-    OUTDOOR_ACTIVITY,
-    SIGHTSEEING,
-    TRAVEL,
-    WELLNESS,
-    SHOPPING,
-    GAMES,
-    SPORTS,
-    WINTERSPORTS
+    COOKING("cooking-pot"),
+    EATING("hamburger"),
+    THEATRE("comedy"),
+    MOVIES("movie-projector"),
+    MUSIC("music"),
+    MUSEUMS("bust"),
+    OUTDOOR_ACTIVITY("campfire"),
+    SIGHTSEEING("camera"),
+    TRAVEL("airport"),
+    WELLNESS("spa-flower"),
+    SHOPPING("shopping-bag"),
+    GAMES("game-controller"),
+    SPORTS("track-and-field"),
+    WINTERSPORTS("skiing");
+
+    public final String icon;
+
+    ActivityCategory(String icon) {
+        this.icon = icon;
+    }
+
+    public String toString() {
+        return this.icon;
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityController.java
@@ -39,7 +39,7 @@ public class ActivityController {
     @ResponseStatus(HttpStatus.OK)
     public Map<ActivityCategory, String> getActivityCategories(){
         return Arrays.stream(ActivityCategory.values())
-                .collect(Collectors.toMap(Function.identity(), ActivityCategory::toString));
+                .collect(Collectors.toMap(Function.identity(), ActivityCategory::getIcon));
     }
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityController.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs21.controller;
 
+import ch.uzh.ifi.hase.soprafs21.constant.ActivityCategory;
 import ch.uzh.ifi.hase.soprafs21.constant.SwipeStatus;
 import ch.uzh.ifi.hase.soprafs21.entities.Activity;
 import ch.uzh.ifi.hase.soprafs21.rest.dto.activityDTO.ActivityGetDTO;
@@ -8,7 +9,11 @@ import ch.uzh.ifi.hase.soprafs21.service.ActivityService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -29,6 +34,14 @@ public class ActivityController {
         List<Activity> activitiesToSwipe = activityService.getActivities(userId, token);
         return DTOMapperActivity.INSTANCE.convertEntityListToActivityGetDTOList(activitiesToSwipe);
     }
+
+    @GetMapping("/activitycategories/")
+    @ResponseStatus(HttpStatus.OK)
+    public Map<ActivityCategory, String> getActivityCategories(){
+        return Arrays.stream(ActivityCategory.values())
+                .collect(Collectors.toMap(Function.identity(), ActivityCategory::toString));
+    }
+
 
     @PutMapping("/activities/swipe/{activityId}")
     @ResponseStatus(HttpStatus.OK)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs21/controller/ActivityControllerTest.java
@@ -43,7 +43,13 @@ public class ActivityControllerTest {
     @MockBean
     private UserService userService;
 
-  
+    @Test
+    public void test_getActivityCategories() throws Exception {
+        MockHttpServletRequestBuilder getRequest = get("/activitycategories/");
+        mockMvc.perform(getRequest).andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(ActivityCategory.values().length))); // check that amount of json entries corresponds to enum entries
+    }
+
     @Test
     public void test_getActivities() throws Exception {
         // given


### PR DESCRIPTION
Adds endpoint `GET /activitycategories` that returns all ActivityCategory enum keys with values (icon class names).
No authentication required.

e.g. response:
```
{
    "SIGHTSEEING": "camera",
    "WINTERSPORTS": "skiing",
    "OUTDOOR_ACTIVITY": "campfire",
    "COOKING": "cooking-pot",
    "THEATRE": "comedy",
    "MUSIC": "music",
    "MOVIES": "movie-projector",
    "MUSEUMS": "bust",
    "SHOPPING": "shopping-bag",
    "EATING": "hamburger",
    "GAMES": "game-controller",
    "WELLNESS": "spa-flower",
    "SPORTS": "track-and-field",
    "TRAVEL": "airport"
}
```

closes #91 